### PR TITLE
issue-3: This fixes an issue where a transient error in the SDK would result in a failure

### DIFF
--- a/lib/constants/incrementalExportDefaults.ts
+++ b/lib/constants/incrementalExportDefaults.ts
@@ -3,4 +3,8 @@ export class IncrementalExportDefaults {
     public static WAIT_TIME_TO_CHECK_EXPORT_STATUS_IN_SECONDS = 10 as number;
     public static DATA_EXPORT_FORMAT = 'DYNAMODB_JSON';
     public static AWS_API_INVOCATION_TIMEOUT_IN_SECONDS = 10 as number;
+    
+    public static SDK_EXCEPTION_RETRY_ATTEMPTS = 5 as number;
+    public static SDK_EXCEPTION_INTERVAL_DURATION_SECONDS = 20 as number;
+    public static SDK_EXCEPTION_BACKOFF_RATE = 1 as number;
 }


### PR DESCRIPTION
This fixes #3 

*Description of changes:*
Added a retry handler for SSM invocations to ensure any transient errors are caught before resulting in a workflow failure
